### PR TITLE
Prevent javascript code from stopping execution

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-formupdatelistener.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-formupdatelistener.js
@@ -8,7 +8,7 @@ define(
             this.updated = false;
             var message = $form.attr('data-updated-message');
             if (!message) {
-                console.error('FormUpdateListener: message not provided.');
+                console.warn('FormUpdateListener: message not provided.');
                 return;
             }
             var title = $form.attr('data-updated-title');


### PR DESCRIPTION
This PR allows the javascript to be executed further even if the flash message is missing (but logs a warning on the console)